### PR TITLE
Swift Optimizer: add def-use/use-def walker utilities

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -45,19 +45,19 @@ struct AliasAnalysis {
   }
 
   /// Returns the correct path for address-alias functions.
-  static func getPtrOrAddressPath(for value: Value) -> EscapeInfo.Path {
+  static func getPtrOrAddressPath(for value: Value) -> SmallProjectionPath {
     let ty = value.type
     if ty.isAddress {
       // This is the regular case: the path selects any sub-fields of an address.
-      return EscapeInfo.Path(.anyValueFields)
+      return SmallProjectionPath(.anyValueFields)
     }
     // Some optimizations use the address-alias APIs with non-address SIL values.
     // TODO: this is non-intuitive and we should eliminate those API uses.
     if ty.isClass {
     // If the value is a (non-address) reference it means: all addresses within the class instance.
-      return EscapeInfo.Path(.anyValueFields).push(.anyClassField)
+      return SmallProjectionPath(.anyValueFields).push(.anyClassField)
     }
     // Any other non-address value means: all addresses of any referenced class instances within the value.
-    return EscapeInfo.Path(.anyValueFields).push(.anyClassField).push(.anyValueFields)
+    return SmallProjectionPath(.anyValueFields).push(.anyClassField).push(.anyValueFields)
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeEffects.swift
@@ -31,10 +31,14 @@ fileprivate typealias Path = ArgumentEffect.Path
 /// In future, this pass may also add other effects, like memory side effects.
 let computeEffects = FunctionPass(name: "compute-effects", {
   (function: Function, context: PassContext) in
-
   var argsWithDefinedEffects = getArgIndicesWithDefinedEffects(of: function)
 
-  var escapeInfo = EscapeInfo(calleeAnalysis: context.calleeAnalysis)
+  struct IgnoreRecursiveCallVisitor : EscapeInfoVisitor {
+    func visitUse(operand: Operand, path: Path, state: State) -> UseResult {
+      return isOperandOfRecursiveCall(operand) ? .ignore : .continueWalk
+    }
+  }
+  var escapeInfo = EscapeInfo(calleeAnalysis: context.calleeAnalysis, visitor: IgnoreRecursiveCallVisitor())
   var newEffects = Stack<ArgumentEffect>(context)
   let returnInst = function.returnInstruction
 
@@ -46,10 +50,7 @@ let computeEffects = FunctionPass(name: "compute-effects", {
     if argsWithDefinedEffects.contains(arg.index) { continue }
     
     // First check: is the argument (or a projected value of it) escaping at all?
-    if !escapeInfo.isEscapingWhenWalkingDown(object: arg, path: Path(.anything),
-        visitUse: { op, _, _ in
-          isOperandOfRecursiveCall(op) ? .ignore : .continueWalking
-        }) {
+    if !escapeInfo.isEscapingWhenWalkingDown(object: arg, path: Path(.anything)) {
       let selectedArg = Selection(arg, pathPattern: Path(.anything))
       newEffects.push(ArgumentEffect(.notEscaping, selectedArg: selectedArg))
       continue
@@ -57,10 +58,10 @@ let computeEffects = FunctionPass(name: "compute-effects", {
   
     // Now compute effects for two important cases:
     //   * the argument itself + any value projections, and...
-    if addArgEffects(arg, argPath: Path(), to: &newEffects, returnInst, &escapeInfo) {
+    if addArgEffects(context: context, arg, argPath: Path(), to: &newEffects, returnInst) {
       //   * single class indirections
-      _ = addArgEffects(arg, argPath: Path(.anyValueFields).push(.anyClassField),
-                        to: &newEffects, returnInst, &escapeInfo)
+      _ = addArgEffects(context: context, arg, argPath: Path(.anyValueFields).push(.anyClassField),
+                        to: &newEffects, returnInst)
     }
   }
 
@@ -71,60 +72,72 @@ let computeEffects = FunctionPass(name: "compute-effects", {
   newEffects.removeAll()
 })
 
+
 /// Returns true if an argument effect was added.
 private
-func addArgEffects(_ arg: FunctionArgument, argPath ap: Path,
+func addArgEffects(context: PassContext, _ arg: FunctionArgument, argPath ap: Path,
                    to newEffects: inout Stack<ArgumentEffect>,
-                   _ returnInst: ReturnInst?,
-                   _ escapeInfo: inout EscapeInfo) -> Bool {
-
-  var toSelection: Selection?
+                   _ returnInst: ReturnInst?) -> Bool {
   // Correct the path if the argument is not a class reference itself, but a value type
   // containing one or more references.
   let argPath = arg.type.isClass ? ap : ap.push(.anyValueFields)
-
-  if escapeInfo.isEscapingWhenWalkingDown(object: arg, path: argPath,
-      visitUse: { op, path, followStores in
-        if op.instruction == returnInst {
-          // The argument escapes to the function return
-          if followStores {
-            // The escaping path must not introduce a followStores.
-            return .markEscaping
-          }
-          if let ta = toSelection {
-            if ta.value != .returnValue { return .markEscaping }
-            toSelection = Selection(.returnValue, pathPattern: path.merge(with: ta.pathPattern))
-          } else {
-            toSelection = Selection(.returnValue, pathPattern: path)
-          }
-          return .ignore
-        }
-        if isOperandOfRecursiveCall(op) {
-          return .ignore
-        }
-        return .continueWalking
-      },
-      visitDef: { def, path, followStores in
-        guard let destArg = def as? FunctionArgument else {
-          return .continueWalkingUp
-        }
-        // The argument escapes to another argument (e.g. an out or inout argument)
-        if followStores {
+  
+  struct ArgEffectsVisitor : EscapeInfoVisitor {
+    init(toSelection: Selection?, returnInst: ReturnInst?) {
+      self.toSelection = toSelection
+      self.returnInst = returnInst
+    }
+    
+    var toSelection: Selection?
+    var returnInst: ReturnInst?
+    
+    mutating func visitUse(operand: Operand, path: Path, state: State) -> UseResult {
+      if operand.instruction == returnInst {
+        // The argument escapes to the function return
+        if state.followStores {
           // The escaping path must not introduce a followStores.
-          return .markEscaping
+          return .abort
         }
-        let argIdx = destArg.index
         if let ta = toSelection {
-          if ta.value != .argument(argIdx) { return .markEscaping }
-          toSelection = Selection(.argument(argIdx), pathPattern: path.merge(with: ta.pathPattern))
+          if ta.value != .returnValue { return .abort }
+          toSelection = Selection(.returnValue, pathPattern: path.merge(with: ta.pathPattern))
         } else {
-          toSelection = Selection(.argument(argIdx), pathPattern: path)
+          toSelection = Selection(.returnValue, pathPattern: path)
         }
-        return .continueWalkingDown
-      }) {
+        return .ignore
+      }
+      if isOperandOfRecursiveCall(operand) {
+        return .ignore
+      }
+      return .continueWalk
+    }
+    
+    mutating func visitDef(def: Value, path: Path, state: State) -> DefResult {
+      guard let destArg = def as? FunctionArgument else {
+        return .continueWalkUp
+      }
+      // The argument escapes to another argument (e.g. an out or inout argument)
+      if state.followStores {
+        // The escaping path must not introduce a followStores.
+        return .abort
+      }
+      let argIdx = destArg.index
+      if let ta = toSelection {
+        if ta.value != .argument(argIdx) { return .abort }
+        toSelection = Selection(.argument(argIdx), pathPattern: path.merge(with: ta.pathPattern))
+      } else {
+        toSelection = Selection(.argument(argIdx), pathPattern: path)
+      }
+      return .walkDown
+    }
+  }
+  
+  var walker = EscapeInfo(calleeAnalysis: context.calleeAnalysis, visitor: ArgEffectsVisitor(toSelection: nil, returnInst: returnInst))
+  if walker.isEscapingWhenWalkingDown(object: arg, path: argPath) {
     return false
   }
-
+  
+  let toSelection = walker.visitor.toSelection
   let fromSelection = Selection(arg, pathPattern: argPath)
 
   guard let toSelection = toSelection else {
@@ -137,7 +150,7 @@ func addArgEffects(_ arg: FunctionArgument, argPath ap: Path,
     return false
   }
 
-  let exclusive = isExclusiveEscape(fromArgument: arg, fromPath: argPath, to: toSelection, returnInst, &escapeInfo)
+  let exclusive = isExclusiveEscape(context: context, fromArgument: arg, fromPath: argPath, to: toSelection, returnInst)
 
   newEffects.push(ArgumentEffect(.escaping(toSelection, exclusive), selectedArg: fromSelection))
   return true
@@ -184,52 +197,70 @@ private func isOperandOfRecursiveCall(_ op: Operand) -> Bool {
 /// there are no other arguments or escape points than `fromArgument`. Also, the
 /// path at the `fromArgument` must match with `fromPath`.
 private
-func isExclusiveEscape(fromArgument: Argument, fromPath: Path, to toSelection: Selection,
-                       _ returnInst: ReturnInst, _ escapeInfo: inout EscapeInfo) -> Bool {
+func isExclusiveEscape(context: PassContext, fromArgument: Argument, fromPath: Path, to toSelection: Selection,
+                       _ returnInst: ReturnInst) -> Bool {
   switch toSelection.value {
   
   // argument -> return
   case .returnValue:
-    if escapeInfo.isEscaping(
-          object: returnInst.operand, path: toSelection.pathPattern,
-          visitUse: { op, path, followStores in
-            if op.instruction == returnInst {
-              if followStores { return .markEscaping }
-              if path.matches(pattern: toSelection.pathPattern) {
-                return .ignore
-              }
-              return .markEscaping
-            }
-            return .continueWalking
-          },
-          visitDef: { def, path, followStores in
-            guard let arg = def as? FunctionArgument else {
-              return .continueWalkingUp
-            }
-            if followStores { return .markEscaping }
-            if arg == fromArgument && path.matches(pattern: fromPath) {
-              return .continueWalkingDown
-            }
-            return .markEscaping
-          }) {
+    struct IsExclusiveReturnEscapeVisitor : EscapeInfoVisitor {
+      let fromArgument: Argument
+      let toSelection: Selection
+      let returnInst: ReturnInst
+      let fromPath: Path
+      
+      mutating func visitUse(operand: Operand, path: Path, state: State) -> UseResult {
+        if operand.instruction == returnInst {
+          if state.followStores { return .abort }
+          if path.matches(pattern: toSelection.pathPattern) {
+            return .ignore
+          }
+          return .abort
+        }
+        return .continueWalk
+      }
+      
+      mutating func visitDef(def: Value, path: Path, state: State) -> DefResult {
+        guard let arg = def as? FunctionArgument else {
+          return .continueWalkUp
+        }
+        if state.followStores { return .abort }
+        if arg == fromArgument && path.matches(pattern: fromPath) {
+          return .walkDown
+        }
+        return .abort
+      }
+    }
+    let visitor = IsExclusiveReturnEscapeVisitor(fromArgument: fromArgument, toSelection: toSelection, returnInst: returnInst, fromPath: fromPath)
+    var walker = EscapeInfo(calleeAnalysis: context.calleeAnalysis, visitor: visitor)
+    if walker.isEscaping(object: returnInst.operand, path: toSelection.pathPattern) {
       return false
     }
-    
   // argument -> argument
   case .argument(let toArgIdx):
+    struct IsExclusiveArgumentEscapeVisitor : EscapeInfoVisitor {
+      let fromArgument: Argument
+      let fromPath: Path
+      let toSelection: Selection
+      let toArg: FunctionArgument
+      
+      mutating func visitDef(def: Value, path: Path, state: State) -> DefResult {
+        guard let arg = def as? FunctionArgument else {
+          return .continueWalkUp
+        }
+        if state.followStores { return .abort }
+        if arg == fromArgument && path.matches(pattern: fromPath) { return .walkDown }
+        if arg == toArg && path.matches(pattern: toSelection.pathPattern) { return .walkDown }
+        return .abort
+      }
+    }
     let toArg = returnInst.function.arguments[toArgIdx]
-    if escapeInfo.isEscaping(object: toArg, path: toSelection.pathPattern,
-        visitDef: { def, path, followStores in
-          guard let arg = def as? FunctionArgument else {
-            return .continueWalkingUp
-          }
-          if followStores { return .markEscaping }
-          if arg == fromArgument && path.matches(pattern: fromPath) { return .continueWalkingDown }
-          if arg == toArg && path.matches(pattern: toSelection.pathPattern) { return .continueWalkingDown }
-          return .markEscaping
-        }) {
+    let visitor = IsExclusiveArgumentEscapeVisitor(fromArgument: fromArgument, fromPath: fromPath, toSelection: toSelection, toArg: toArg)
+    var walker = EscapeInfo(calleeAnalysis: context.calleeAnalysis, visitor: visitor)
+    if walker.isEscaping(object: toArg, path: toSelection.pathPattern) {
       return false
     }
   }
   return true
 }
+

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/CMakeLists.txt
@@ -8,4 +8,6 @@
 
 swift_compiler_sources(Optimizer
   EscapeInfo.swift
-  OptUtils.swift)
+  OptUtils.swift
+  WalkUtils.swift
+)

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeInfo.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeInfo.swift
@@ -12,6 +12,31 @@
 
 import SIL
 
+/// This protocol is used to customize `EscapeInfo` by implementing `visitUse` and
+/// `visitDef` which are called for all uses and definitions ("direct" and "transitive") encountered
+/// during a walk.
+protocol EscapeInfoVisitor {
+  typealias Path = SmallProjectionPath
+  typealias UseResult = EscapeInfo<Self>.UseVisitResult
+  typealias DefResult = EscapeInfo<Self>.DefVisitResult
+  typealias State = EscapeInfo<Self>.State
+  
+  /// Called during the DefUse walk for each use
+  mutating func visitUse(operand: Operand, path: Path, state: State) -> UseResult
+  
+  /// Called during the UseDef walk for each definition
+  mutating func visitDef(def: Value, path: Path, state: State) -> DefResult
+}
+
+extension EscapeInfoVisitor {
+  mutating func visitUse(operand: Operand, path: Path, state: State) -> UseResult {
+    return .continueWalk
+  }
+  mutating func visitDef(def: Value, path: Path, state: State) -> DefResult {
+    return .continueWalkUp
+  }
+}
+
 /// A utility for checking if a value escapes and for finding the escape points.
 ///
 /// The EscapeInfo starts at the initial value and alternately walks in two directions:
@@ -70,37 +95,52 @@ import SIL
 /// the value, escapes.
 /// An exception are `isEscaping(address: Value)` and similar functions: they ignore
 /// values which are loaded from the address in question.
-struct EscapeInfo {
-
+struct EscapeInfo<V: EscapeInfoVisitor> {
+  struct State {
+    var followStores: Bool
+    var knownType: Type?
+    
+    func with(followStores: Bool) -> Self {
+      return Self(followStores: followStores, knownType: self.knownType)
+    }
+    
+    func with(knownType: Type?) -> Self {
+      return Self(followStores: self.followStores, knownType: knownType)
+    }
+  }
+  
   typealias Path = SmallProjectionPath
 
-  public enum UseCallbackResult {
+  enum DefVisitResult {
     case ignore
-    case markEscaping
-    case continueWalking
+    case continueWalkUp
+    case walkDown
+    case abort
   }
 
-  /// Called for all operands with the current path and `followStores` when walking down.
-  typealias UseCallback = (Operand, Path, Bool) -> UseCallbackResult
-
-  public enum DefCallbackResult {
+  enum UseVisitResult {
     case ignore
-    case markEscaping
-    case continueWalkingUp
-    case continueWalkingDown
+    case continueWalk
+    case abort
   }
-
-  /// Called for all values with the current path and `followStores` when walking up.
-  typealias DefCallback = (Value, Path, Bool) -> DefCallbackResult
-
+  
   //===--------------------------------------------------------------------===//
   //                           The top-level API
   //===--------------------------------------------------------------------===//
 
-  init(calleeAnalysis: CalleeAnalysis) {
-    self.calleeAnalysis = calleeAnalysis
+  init(calleeAnalysis: CalleeAnalysis, visitor: V) {
+    self.walker = EscapeInfoWalker(calleeAnalysis: calleeAnalysis, visitor: visitor)
   }
-
+  private var walker: EscapeInfoWalker<V>
+  
+  /// Returns the visitor passed as argument during initialization.
+  /// It is also possible to mutate the visitor to reuse it for performance. See ``EscapeAliasAnalysis/canReferenceSameField``.
+  var visitor: V {
+    get { walker.visitor }
+    
+    _modify { yield &walker.visitor }
+  }
+  
   /// Returns true if `object`, or any sub-objects which are selected by `path`, can escape.
   ///
   /// For example, let's assume this function is called with a struct, containing a reference,
@@ -115,28 +155,25 @@ struct EscapeInfo {
   /// \endcode
   ///
   /// Trivial values are ignored, even if they are selected by `path`.
-  mutating func isEscaping(object: Value, path: Path = Path(),
-                           visitUse: UseCallback = { _, _, _ in .continueWalking },
-                           visitDef: DefCallback = { _, _, _ in .continueWalkingUp }) -> Bool {
-    start(forAnalyzingAddresses: false)
-    defer { cleanup() }
-
-    return walkUpAndCache(object, path: path, followStores: false,
-                          visitUse: visitUse, visitDef: visitDef)
+  mutating func isEscaping(object: Value, path: Path = Path()) -> Bool {
+    walker.start(forAnalyzingAddresses: false)
+    defer { walker.cleanup() }
+    
+    let state = State(followStores: false, knownType: nil)
+    if let (path, state) = walker.shouldRecomputeUp(def: object, path: path, state: state) {
+      return walker.walkUp(addressOrValue: object, path: path, state: state)
+    }
+    return false
   }
 
   /// Returns true if the definition of `value` is escaping.
   ///
-  /// In contrast to `isEscaping`, this function starts with a walk-up instead of a walk-down from `value`.
-  mutating func isEscapingWhenWalkingDown(object: Value,
-                      path: Path = Path(),
-                      visitUse: UseCallback = { _, _, _ in .continueWalking },
-                      visitDef: DefCallback = { _, _, _ in .continueWalkingUp }) -> Bool {
-    start(forAnalyzingAddresses: false)
-    defer { cleanup() }
-
-    return walkDownAndCache(object, path: path, followStores: false, knownType: nil,
-                            visitUse: visitUse, visitDef: visitDef)
+  /// In contrast to `isEscaping`, this function starts with a walk-down instead of a walk-up from `value`.
+  mutating func isEscapingWhenWalkingDown(object: Value, path: Path = Path()) -> Bool {
+    walker.start(forAnalyzingAddresses: false)
+    defer { walker.cleanup() }
+    
+    return walker.cachedWalkDown(addressOrValue: object, path: path, state: State(followStores: false, knownType: nil))
   }
 
   /// Returns true if any address of `value`, which is selected by `path`, can escape.
@@ -155,15 +192,44 @@ struct EscapeInfo {
   ///   not the value stored at the address.
   /// * Addresses with trivial types are _not_ ignored.
   mutating
-  func isEscaping(addressesOf value: Value, path: Path = Path(.anyValueFields),
-                  visitUse: UseCallback = { _, _, _ in .continueWalking },
-                  visitDef: DefCallback = { _, _, _ in .continueWalkingUp }) -> Bool {
-    start(forAnalyzingAddresses: true)
-    defer { cleanup() }
-
-    return walkUpAndCache(value, path: path, followStores: false, visitUse: visitUse, visitDef: visitDef)
+  func isEscaping(addressesOf value: Value, path: Path = Path(.anyValueFields)) -> Bool {
+    walker.start(forAnalyzingAddresses: true)
+    defer { walker.cleanup() }
+    
+    let state = State(followStores: false, knownType: nil)
+    if let (path, state) = walker.shouldRecomputeUp(def: value, path: path, state: state) {
+      return walker.walkUp(addressOrValue: value, path: path, state: state)
+    }
+    return false
   }
+}
 
+/// A lightweight form of AliasAnalysis that checks whether given two addresses can alias
+/// by checking that the addresses don't escape and that during a walk of one of
+/// the values, a use does not result in the other value.
+struct EscapeAliasAnalysis {
+  typealias Path = SmallProjectionPath
+  
+  private struct Visitor : EscapeInfoVisitor {
+    // TODO: maybe we can create an empty value instead of option?
+    var target: Value?
+    func visitUse(operand: Operand, path: Path, state: State) -> UseResult {
+      // Note: since we are checking the value of an operand, we are ignoring address
+      // projections with no uses. This is no problem. It just requires a fix_lifetime for
+      // each address to test in alias-analysis test files.
+      if operand.value == target! { return .abort }
+      if operand.instruction is ReturnInst { return .ignore }
+      return .continueWalk
+    }
+  }
+  
+  private var calleeAnalysis: CalleeAnalysis
+  private var walker: EscapeInfo<Visitor>
+  init(calleeAnalysis: CalleeAnalysis) {
+    self.calleeAnalysis = calleeAnalysis
+    self.walker = EscapeInfo(calleeAnalysis: calleeAnalysis, visitor: Visitor())
+  }
+  
   /// Returns true if the selected address(es) of `lhs`/`lhsPath` can reference the same field as
   /// the selected address(es) of `rhs`/`rhsPath`.
   ///
@@ -173,32 +239,553 @@ struct EscapeInfo {
   ///
   mutating func canReferenceSameField(_ lhs: Value, path lhsPath: Path = Path(.anyValueFields),
                                       _ rhs: Value, path rhsPath: Path = Path(.anyValueFields)) -> Bool {
+    
     // lhs -> rhs will succeed (= return false) if lhs is a non-escaping "local" object,
     // but not necessarily rhs.
-    if !isEscaping(addressesOf: lhs, path: lhsPath,
-      visitUse: { op, _, _ in
-        // Note: since we are checking the vale of an operand, we are ignoring address
-        // projections with no uses. This is no problem. It just requires a fix_lifetime for
-        // each address to test in alias-analysis test files.
-        if op.value == rhs { return .markEscaping }
-        if op.instruction is ReturnInst { return .ignore }
-        return .continueWalking
-      }) {
+    walker.visitor.target = rhs
+    if walker.isEscaping(addressesOf: lhs, path: lhsPath) {
       return false
     }
     // The other way round: rhs -> lhs will succeed if rhs is a non-escaping "local" object,
     // but not necessarily lhs.
-    if !isEscaping(addressesOf: rhs, path: rhsPath,
-      visitUse: { op, _, _ in
-        if op.value == lhs { return .markEscaping }
-        if op.instruction is ReturnInst { return .ignore }
-        return .continueWalking
-      }) {
+    walker.visitor.target = lhs
+    if walker.isEscaping(addressesOf: rhs, path: rhsPath) {
       return false
     }
     return true
   }
+}
 
+
+/// The walker used by `EscapeInfo` to check whether a value escapes.
+/// It is both a DefUse walker and UseDef walker. If during a walkDown a store or copy
+/// is reached then
+fileprivate struct EscapeInfoWalker<V: EscapeInfoVisitor> : ValueDefUseWalker,
+                                                            AddressDefUseWalker,
+                                                            ValueUseDefWalker,
+                                                            AddressUseDefWalker {
+  typealias State = EscapeInfo<V>.State
+  
+  init(calleeAnalysis: CalleeAnalysis, visitor: V) {
+    self.calleeAnalysis = calleeAnalysis
+    self.visitor = visitor
+  }
+  
+  mutating func start(forAnalyzingAddresses: Bool) {
+    precondition(walkedDownCache.isEmpty && walkedUpCache.isEmpty)
+    analyzeAddresses = forAnalyzingAddresses
+  }
+
+  mutating func cleanup() {
+    walkedDownCache.removeAll(keepingCapacity: true)
+    walkedUpCache.removeAll(keepingCapacity: true)
+  }
+
+  //===--------------------------------------------------------------------===//
+  //                                   Walking down
+  //===--------------------------------------------------------------------===//
+  
+  /// Main entry point called by ``EscapeInfo``
+  mutating func cachedWalkDown(addressOrValue: Value, path: Path, state: State) -> Bool {
+    if let (path, state) = shouldRecomputeDown(def: addressOrValue, path: path, state: state) {
+      return walkDown(addressOrValue: addressOrValue, path: path, state: state)
+    } else {
+      return false
+    }
+  }
+  
+  mutating func walkDown(addressOrValue: Value, path: Path, state: State) -> Bool {
+    if addressOrValue.type.isAddress {
+      return walkDownUses(ofAddress: addressOrValue, path: path, state: state)
+    } else {
+      return walkDownUses(ofValue: addressOrValue, path: path, state: state)
+    }
+  }
+  
+  mutating func walkDown(value: Operand, path: Path, state: State) -> Bool {
+    if hasRelevantType(value.value, at: path) {
+      switch visitor.visitUse(operand: value, path: path, state: state) {
+      case .continueWalk:
+        return walkDownDefault(value: value, path: path, state: state)
+      case .ignore:
+        return false
+      case .abort:
+        return true
+      }
+    }
+    return false
+  }
+  
+  /// ``ValueDefUseWalker`` conformance: called when the value def-use walk can't continue,
+  /// i.e. when the result of the use is not a value.
+  mutating func leafUse(value operand: Operand, path: Path, state: State) -> Bool {
+    let instruction = operand.instruction
+    switch instruction {
+    case let rta as RefTailAddrInst:
+      if let path = pop(.tailElements, from: path, yielding: rta) {
+        return walkDownUses(ofAddress: rta, path: path, state: state.with(knownType: nil))
+      }
+    case let rea as RefElementAddrInst:
+      if let path = pop(.classField, index: rea.fieldIndex, from: path, yielding: rea) {
+        return walkDownUses(ofAddress: rea, path: path, state: state.with(knownType: nil))
+      }
+    case let pb as ProjectBoxInst:
+      if let path = pop(.classField, index: pb.fieldIndex, from: path, yielding: pb) {
+        return walkDownUses(ofAddress: pb, path: path, state: state.with(knownType: nil))
+      }
+    case let se as SwitchEnumInst:
+      if let (caseIdx, path) = path.pop(kind: .enumCase),
+         let succBlock = se.getUniqueSuccessor(forCaseIndex: caseIdx),
+         let payload = succBlock.arguments.first {
+        return walkDownUses(ofValue: payload, path: path, state: state)
+      } else if path.topMatchesAnyValueField {
+        for succBlock in se.block.successors {
+          if let payload = succBlock.arguments.first,
+             walkDownUses(ofValue: payload, path: path, state: state) {
+            return true
+          }
+        }
+        return true
+      } else {
+        return true
+      }
+    case is StoreInst, is StoreWeakInst, is StoreUnownedInst:
+      let store = instruction as! StoringInstruction
+      assert(operand == store.sourceOperand )
+      return walkUp(address: store.destination, path: path, state: state)
+    case is DestroyValueInst, is ReleaseValueInst, is StrongReleaseInst:
+      if handleDestroy(of: operand.value, path: path, followStores: state.followStores, knownType: state.knownType) {
+        return true
+      }
+    case is ReturnInst:
+      return isEscaping
+    case is ApplyInst, is TryApplyInst, is BeginApplyInst:
+      return walkDownCallee(argOp: operand, apply: instruction as! FullApplySite, path: path, state: state)
+    case let pai as PartialApplyInst:
+      // This is a non-stack closure.
+      // For `stack` closures, `hasRelevantType` in `walkDown` will return false
+      // stopping the walk since they don't escape.
+      
+      // Check whether the partially applied argument can escape in the body.
+      if walkDownCallee(argOp: operand, apply: pai, path: path, state: state.with(knownType: nil)) {
+        return true
+      }
+      
+      // Additionally we need to follow the partial_apply value for two reasons:
+      // 1. the closure (with the captured values) itself can escape
+      //    and the use "transitively" escapes
+      // 2. something can escape in a destructor when the context is destroyed
+      return walkDownUses(ofValue: pai, path: path, state: state.with(knownType: nil))
+    case let pta as PointerToAddressInst:
+      assert(operand.index == 0)
+      return walkDownUses(ofAddress: pta, path: path, state: state.with(knownType: nil))
+    case let bi as BuiltinInst:
+      switch bi.id {
+      case .DestroyArray:
+        if operand.index != 1 ||
+            path.popAllValueFields().popIfMatches(.anyClassField) != nil {
+          return isEscaping
+        }
+      default:
+        return isEscaping
+      }
+    case is StrongRetainInst, is RetainValueInst, is DebugValueInst, is ValueMetatypeInst,
+      is InitExistentialMetatypeInst, is OpenExistentialMetatypeInst,
+      is ExistentialMetatypeInst, is DeallocRefInst, is SetDeallocatingInst, is FixLifetimeInst,
+      is ClassifyBridgeObjectInst, is BridgeObjectToWordInst, is EndBorrowInst,
+      is StrongRetainInst, is RetainValueInst,
+      is ClassMethodInst, is SuperMethodInst, is ObjCMethodInst,
+      is ObjCSuperMethodInst, is WitnessMethodInst, is DeallocStackRefInst:
+      return false
+    case is DeallocStackInst:
+      // dealloc_stack %f : $@noescape @callee_guaranteed () -> ()
+      // type is a value
+      assert(operand.value.definingInstruction is PartialApplyInst)
+      return false
+    default:
+      return isEscaping
+    }
+    return false
+  }
+  
+  mutating func walkDown(address: Operand, path: Path, state: State) -> Bool {
+    if hasRelevantType(address.value, at: path) {
+      switch visitor.visitUse(operand: address, path: path, state: state) {
+      case .continueWalk:
+        return walkDownDefault(address: address, path: path, state: state)
+      case .ignore:
+        return false
+      case .abort:
+        return true
+      }
+    }
+    return false
+  }
+  
+  /// ``AddressDefUseWalker`` conformance: called when the address def-use walk can't continue,
+  /// i.e. when the result of the use is not an address.
+  mutating func leafUse(address operand: Operand, path: Path, state: State) -> Bool {
+    let instruction = operand.instruction
+    switch instruction {
+    case is StoreInst, is StoreWeakInst, is StoreUnownedInst:
+      let store = instruction as! StoringInstruction
+      assert(operand == store.destinationOperand)
+      if let si = store as? StoreInst, si.destinationOwnership == .assign {
+        if handleDestroy(of: operand.value, path: path, followStores: state.followStores, knownType: nil) {
+          return true
+        }
+      }
+      if state.followStores {
+        return walkUp(value: store.source, path: path, state: state)
+      }
+    case let copyAddr as CopyAddrInst:
+      if canIgnoreForLoadOrArgument(path) { return false }
+      if operand == copyAddr.sourceOperand {
+        return walkUp(address: copyAddr.destination, path: path, state: state)
+      } else {
+        if !copyAddr.isInitializationOfDest {
+          if handleDestroy(of: operand.value, path: path, followStores: state.followStores, knownType: nil) {
+            return true
+          }
+        }
+        
+        if state.followStores {
+          assert(operand == copyAddr.destinationOperand)
+          return walkUp(value: copyAddr.source, path: path, state: state)
+        }
+      }
+    case is DestroyAddrInst:
+      if handleDestroy(of: operand.value, path: path, followStores: state.followStores, knownType: state.knownType) {
+        return true
+      }
+    case is ReturnInst:
+      return isEscaping
+    case is ApplyInst, is TryApplyInst, is BeginApplyInst:
+      return walkDownCallee(argOp: operand, apply: instruction as! FullApplySite, path: path, state: state)
+    case let pai as PartialApplyInst:
+      if walkDownCallee(argOp: operand, apply: pai, path: path, state: state.with(knownType: nil)) {
+        return true
+      }
+
+      // We need to follow the partial_apply value for two reasons:
+      // 1. the closure (with the captured values) itself can escape
+      // 2. something can escape in a destructor when the context is destroyed
+      return walkDownUses(ofValue: pai, path: path, state: state.with(knownType: nil))
+    case is LoadInst, is LoadWeakInst, is LoadUnownedInst:
+      if canIgnoreForLoadOrArgument(path) { return false }
+      let svi = instruction as! SingleValueInstruction
+      
+      // Even when analyzing addresses, a loaded trivial value can be ignored.
+      if !svi.type.isNonTrivialOrContainsRawPointer(in: svi.function) { return false }
+      return walkDownUses(ofValue: svi, path: path, state: state.with(knownType: nil))
+    case let atp as AddressToPointerInst:
+      return walkDownUses(ofValue: atp, path: path, state: state.with(knownType: nil))
+    case let ia as IndexAddrInst:
+      assert(operand.index == 0)
+      return walkDownUses(ofAddress: ia, path: path, state: state.with(knownType: nil))
+    case is DeallocStackInst, is InjectEnumAddrInst, is FixLifetimeInst, is EndBorrowInst, is EndAccessInst:
+      return false
+    default:
+      return isEscaping
+    }
+    return false
+  }
+  
+  /// Check whether the value escapes through the deinitializer
+  private func handleDestroy(of value: Value, path: SmallProjectionPath, followStores: Bool, knownType: Type?) -> Bool {
+
+    // Even if this is a destroy_value of a struct/tuple/enum, the called destructor(s) only take a
+    // single class reference as parameter.
+    let p = path.popAllValueFields()
+
+    if p.isEmpty {
+      // The object to destroy (= the argument of the destructor) cannot escape itself.
+      return false
+    }
+    if analyzeAddresses && p.matches(pattern: SmallProjectionPath(.anyValueFields).push(.anyClassField)) {
+      // Any address of a class property of the object to destroy cannot esacpe the destructor.
+      // (Whereas a value stored in such a property could escape.)
+      return false
+    }
+
+    if followStores {
+      return isEscaping
+    }
+    if let exactTy = knownType {
+      guard let destructor = calleeAnalysis.getDestructor(ofExactType: exactTy) else {
+        return isEscaping
+      }
+      if destructor.effects.canEscape(argumentIndex: 0, path: p, analyzeAddresses: analyzeAddresses) {
+        return isEscaping
+      }
+    } else {
+      // We don't know the exact type, so get all possible called destructure from
+      // the callee analysis.
+      guard let destructors = calleeAnalysis.getDestructors(of: value.type) else {
+        return isEscaping
+      }
+      for destructor in destructors {
+        if destructor.effects.canEscape(argumentIndex: 0, path: p, analyzeAddresses: analyzeAddresses) {
+          return isEscaping
+        }
+      }
+    }
+    return false
+  }
+  
+  /// Handle an apply (full or partial) during the walk-down.
+  private mutating
+  func walkDownCallee(argOp: Operand, apply: ApplySite,
+                      path: Path, state: State) -> Bool {
+    guard let argIdx = apply.argumentIndex(of: argOp) else {
+      // The callee or a type dependent operand of the apply does not let escape anything.
+      return false
+    }
+
+    if canIgnoreForLoadOrArgument(path) { return false }
+
+    // Argument effects do not consider any potential stores to the argument (or it's content).
+    // Therefore, if we need to track stores, the argument effects do not correctly describe what we need.
+    // For example, argument 0 in the following function is marked as not-escaping, although there
+    // is a store to the argument:
+    //
+    //   sil [escapes !%0.**] @callee(@inout X, @owned X) -> () {
+    //   bb0(%0 : $*X, %1 : $X):
+    //     store %1 to %0 : $*X
+    //   }
+    if state.followStores { return isEscaping }
+
+    guard let callees = calleeAnalysis.getCallees(callee: apply.callee) else {
+      // The callees are not know, e.g. if the callee is a closure, class method, etc.
+      return isEscaping
+    }
+
+    let calleeArgIdx = apply.calleeArgIndex(callerArgIndex: argIdx)
+
+    for callee in callees {
+      let effects = callee.effects
+      if !effects.canEscape(argumentIndex: calleeArgIdx, path: path, analyzeAddresses: analyzeAddresses) {
+        continue
+      }
+      if walkDownArgument(calleeArgIdx: calleeArgIdx, argPath: path, state: state,
+                          apply: apply, effects: effects) {
+        return isEscaping
+      }
+    }
+    return false
+  }
+  
+  /// Handle `.escaping` effects for an apply argument during the walk-down.
+  private mutating
+  func walkDownArgument(calleeArgIdx: Int, argPath: Path, state: State,
+                        apply: ApplySite, effects: FunctionEffects) -> Bool {
+    var matched = false
+    for effect in effects.argumentEffects {
+      guard case .escaping(let to, let exclusive) = effect.kind else {
+        continue
+      }
+      if effect.selectedArg.matches(.argument(calleeArgIdx), argPath) {
+        matched = true
+
+        switch to.value {
+        case .returnValue:
+          guard let fas = apply as? FullApplySite, let result = fas.singleDirectResult else { return isEscaping }
+          
+          let state = (exclusive ? state : state.with(knownType: nil)).with(followStores: false)
+          
+          if walkDownUses(ofValue: result, path: to.pathPattern, state: state) {
+            return isEscaping
+          }
+        case .argument(let toArgIdx):
+          guard let callerToIdx = apply.callerArgIndex(calleeArgIndex: toArgIdx) else {
+            return isEscaping
+          }
+
+          // Continue at the destination of an arg-to-arg escape.
+          let arg = apply.arguments[callerToIdx]
+          
+          let state = state.with(knownType: nil).with(followStores: false)
+          if walkUp(addressOrValue: arg, path: to.pathPattern, state: state) {
+            return true
+          }
+        }
+        continue
+      }
+      // Handle the reverse direction of an arg-to-arg escape.
+      if to.matches(.argument(calleeArgIdx), argPath) {
+        guard let callerArgIdx = apply.callerArgIndex(calleeArgIndex: effect.selectedArg.argumentIndex) else {
+          return isEscaping
+        }
+        if !exclusive { return isEscaping }
+
+        matched = true
+        
+        let arg = apply.arguments[callerArgIdx]
+        let state = state.with(followStores: false).with(knownType: nil)
+
+        if walkUp(addressOrValue: arg, path: effect.selectedArg.pathPattern, state: state) {
+          return true
+        }
+        continue
+      }
+    }
+    if !matched { return isEscaping }
+    return false
+  }
+  
+  mutating func shouldRecomputeDown(def: Value, path: Path, state: State) -> (Path, State)? {
+    if let entry = walkedDownCache[def.hashable, default: CacheEntry()].needWalk(path: path, followStores: state.followStores, knownType: state.knownType) {
+      return (entry.path, state.with(knownType: entry.knownType).with(followStores: entry.followStores))
+    }
+    return nil
+  }
+  
+  //===--------------------------------------------------------------------===//
+  //                                   Walking up
+  //===--------------------------------------------------------------------===//
+  
+  /// Main entry point called by ``EscapeInfo``
+  mutating func walkUp(addressOrValue: Value, path: Path, state: State) -> Bool {
+    if addressOrValue.type.isAddress {
+      return walkUp(address: addressOrValue, path: path, state: state)
+    } else {
+      return walkUp(value: addressOrValue, path: path, state: state)
+    }
+  }
+  
+  mutating func walkUp(value: Value, path: Path, state: State) -> Bool {
+    if hasRelevantType(value, at: path) {
+      switch visitor.visitDef(def: value, path: path, state: state) {
+      case .continueWalkUp:
+        return walkUpDefault(value: value, path: path, state: state)
+      case .walkDown:
+        return cachedWalkDown(addressOrValue: value, path: path, state: state.with(knownType: nil))
+      case .ignore:
+        return false
+      case .abort:
+        return true
+      }
+    }
+    return false
+  }
+  
+  /// ``ValueUseDefWalker`` conformance: called when the value use-def walk can't continue,
+  /// i.e. when the operand (if any) of the instruction of a definition is not a value.
+  mutating func rootDef(value def: Value, path: Path, state: State) -> Bool {
+    let state = state.with(knownType: nil)
+    switch def {
+    case is AllocRefInst, is AllocRefDynamicInst:
+      return cachedWalkDown(addressOrValue: def, path: path, state: state.with(knownType: def.type))
+    case is AllocBoxInst:
+      return cachedWalkDown(addressOrValue: def, path: path, state: state)
+    case let arg as BlockArgument:
+      let block = arg.block
+      switch block.singlePredecessor!.terminator {
+      case let se as SwitchEnumInst:
+        guard let caseIdx = se.getUniqueCase(forSuccessor: block) else {
+          return isEscaping
+        }
+        return walkUp(value: se.enumOp, path: path.push(.enumCase, index: caseIdx), state: state)
+      case let ta as TryApplyInst:
+        if block != ta.normalBlock { return isEscaping }
+        return walkUpApplyResult(apply: ta, path: path, state: state)
+      default:
+        return isEscaping
+      }
+    case let ap as ApplyInst:
+      return walkUpApplyResult(apply: ap, path: path, state: state)
+    case is LoadInst, is LoadWeakInst, is LoadUnownedInst:
+      return walkUp(address: (def as! UnaryInstruction).operand,
+                    path: path, state: state.with(followStores: true))
+    case let atp as AddressToPointerInst:
+      return walkUp(address: atp.operand, path: path, state: state)
+    default:
+      return isEscaping
+    }
+  }
+  
+  mutating func walkUp(address: Value, path: Path, state: State) -> Bool {
+    if hasRelevantType(address, at: path) {
+      switch visitor.visitDef(def: address, path: path, state: state) {
+      case .continueWalkUp:
+        return walkUpDefault(address: address, path: path, state: state)
+      case .walkDown:
+        return cachedWalkDown(addressOrValue: address, path: path, state: state)
+      case .ignore:
+        return false
+      case .abort:
+        return true
+      }
+    }
+    return false
+  }
+  
+  /// ``AddressUseDefWalker`` conformance: called when the address use-def walk can't continue,
+  /// i.e. when the operand (if any) of the instruction of a definition is not an address.
+  mutating func rootDef(address def: Value, path: SmallProjectionPath, state: State) -> Bool {
+    let state = state.with(knownType: nil)
+    switch def {
+    case is AllocStackInst:
+      return cachedWalkDown(addressOrValue: def, path: path, state: state)
+    case let arg as FunctionArgument:
+      if canIgnoreForLoadOrArgument(path) && arg.isExclusiveIndirectParameter && !state.followStores {
+        return cachedWalkDown(addressOrValue: def, path: path, state: state)
+      } else {
+        return isEscaping
+      }
+    case is PointerToAddressInst, is IndexAddrInst:
+      return walkUp(value: (def as! SingleValueInstruction).operands[0].value, path: path, state: state)
+    case let rta as RefTailAddrInst:
+      return walkUp(value: rta.operand, path: path.push(.tailElements), state: state)
+    case let rea as RefElementAddrInst:
+      return walkUp(value: rea.operand, path: path.push(.classField, index: rea.fieldIndex), state: state)
+    case let pb as ProjectBoxInst:
+      return walkUp(value: pb.operand, path: path.push(.classField, index: pb.fieldIndex), state: state)
+    default:
+      return isEscaping
+    }
+  }
+  
+  /// Walks up from the return to the source argument if there is an "exclusive"
+  /// escaping effect on an argument.
+  private mutating
+  func walkUpApplyResult(apply: FullApplySite,
+                         path: Path, state: State) -> Bool {
+    guard let callees = calleeAnalysis.getCallees(callee: apply.callee) else {
+      return true
+    }
+
+    for callee in callees {
+      var matched = false
+      for effect in callee.effects.argumentEffects {
+        switch effect.kind {
+        case .notEscaping:
+          break
+        case .escaping(let toSelectedArg, let exclusive):
+          if exclusive && toSelectedArg.matches(.returnValue, path) {
+            matched = true
+            let arg = apply.arguments[effect.selectedArg.argumentIndex]
+            
+            if walkUp(addressOrValue: arg, path: effect.selectedArg.pathPattern, state: state.with(knownType: nil)) {
+              return true
+            }
+          }
+        }
+      }
+      if !matched {
+        return isEscaping
+      }
+    }
+    return false
+  }
+  
+  mutating func shouldRecomputeUp(def: Value, path: Path, state: State) -> (Path, State)? {
+    if let entry = walkedUpCache[def.hashable, default: CacheEntry()].needWalk(path: path, followStores: state.followStores, knownType: state.knownType) {
+      return (entry.path, state.with(knownType: entry.knownType).with(followStores: entry.followStores))
+    }
+    return nil
+  }
+  
   //===--------------------------------------------------------------------===//
   //                             private state
   //===--------------------------------------------------------------------===//
@@ -247,6 +834,8 @@ struct EscapeInfo {
     }
   }
 
+  var visitor: V
+
   // The caches are not only useful for performance, but are need to avoid infinite
   // recursions of walkUp-walkDown cycles.
   private var walkedDownCache = Dictionary<HashableValue, CacheEntry>()
@@ -263,16 +852,6 @@ struct EscapeInfo {
   //===--------------------------------------------------------------------===//
   //                          private utility functions
   //===--------------------------------------------------------------------===//
-
-  private mutating func start(forAnalyzingAddresses: Bool) {
-    precondition(walkedDownCache.isEmpty && walkedUpCache.isEmpty)
-    analyzeAddresses = forAnalyzingAddresses
-  }
-
-  private mutating func cleanup() {
-    walkedDownCache.removeAll(keepingCapacity: true)
-    walkedUpCache.removeAll(keepingCapacity: true)
-  }
 
   /// Returns true if the type of `value` at `path` is relevant and should be tracked.
   private func hasRelevantType(_ value: Value, at path: Path) -> Bool {
@@ -313,692 +892,9 @@ struct EscapeInfo {
     }
     return nil
   }
-
+  
   // Set a breakpoint here to debug when a value is escaping.
   private var isEscaping: Bool {
     true
-  }
-
-  //===--------------------------------------------------------------------===//
-  //                           walk-down functions
-  //===--------------------------------------------------------------------===//
- 
-  /// The entry point to the down-walk.
-  ///
-  /// It's a no-op if the walkDown is already cached, i.e was already done before with
-  /// the same/matching `path`, `followStores` and `knownType`.
-  ///
-  /// In addition to the other common arguments, the `knownType` - if not nil - is the exact type
-  /// of `value`. This is used for analysing releases by lookup up the knownType's destructor.
-  ///
-  /// Returns true if the `value` escapes.
-  private mutating
-  func walkDownAndCache(_ value: Value, path: Path, followStores: Bool,
-                        knownType: Type?,
-                        visitUse: UseCallback, visitDef: DefCallback) -> Bool {
-    if let entry = walkedDownCache[value.hashable, default: CacheEntry()].needWalk(path: path, followStores: followStores, knownType: knownType) {
-      return walkDown(value, path: entry.path, followStores: entry.followStores, knownType: entry.knownType,
-                      visitUse: visitUse, visitDef: visitDef)
-    }
-    return false
-  }
-
-  /// Recursively walks down defs to uses, handling all relevant instructions.
-  ///
-  /// Returns true if the `value` escapes.
-  private mutating
-  func walkDown(_ value: Value, path: Path, followStores: Bool, knownType: Type?,
-                visitUse: UseCallback, visitDef: DefCallback) -> Bool {
-    for use in value.uses {
-      if use.isTypeDependent { continue}
-
-      switch visitUse(use, path, followStores) {
-        case .ignore:
-          continue
-        case .markEscaping:
-          return isEscaping
-        case .continueWalking:
-          break
-      }
-
-      let user = use.instruction
-      switch user {
-        case let rta as RefTailAddrInst:
-          if let newPath = pop(.tailElements, from: path, yielding: rta) {
-            if walkDown(rta, path: newPath, followStores: followStores, knownType: nil,
-                        visitUse: visitUse, visitDef: visitDef) {
-              return true
-            }
-          }
-        case let rea as RefElementAddrInst:
-          if let newPath = pop(.classField, index: rea.fieldIndex, from: path, yielding: rea) {
-            if walkDown(rea, path: newPath, followStores: followStores, knownType: nil,
-                        visitUse: visitUse, visitDef: visitDef) {
-              return true
-            }
-          }
-        case let pb as ProjectBoxInst:
-          if let newPath = pop(.classField, index: pb.fieldIndex, from: path, yielding: pb) {
-            if walkDown(pb, path: newPath, followStores: followStores, knownType: nil,
-                        visitUse: visitUse, visitDef: visitDef) {
-              return true
-            }
-          }
-        case let str as StructInst:
-          if walkDown(str, path: path.push(.structField, index: use.index),
-                      followStores: followStores, knownType: knownType,
-                      visitUse: visitUse, visitDef: visitDef) {
-            return true
-          }
-        case let se as StructExtractInst:
-          if let newPath = pop(.structField, index: se.fieldIndex, from: path, yielding: se) {
-            if walkDown(se, path: newPath, followStores: followStores, knownType: knownType,
-                        visitUse: visitUse, visitDef: visitDef) {
-              return true
-            }
-          }
-        case let ds as DestructureStructInst:
-          if walkDownInstructionResults(results: ds.results,
-                fieldKind: .structField, path: path, followStores: followStores, knownType: knownType,
-                visitUse: visitUse, visitDef: visitDef) {
-            return true
-          }
-        case let dt as DestructureTupleInst:
-          if walkDownInstructionResults(results: dt.results,
-                fieldKind: .tupleField, path: path, followStores: followStores, knownType: knownType,
-                visitUse: visitUse, visitDef: visitDef) {
-            return true
-          }
-        case let sea as StructElementAddrInst:
-          if let newPath = pop(.structField, index: sea.fieldIndex, from: path, yielding: sea) {
-            if walkDown(sea, path: newPath, followStores: followStores, knownType: nil,
-                        visitUse: visitUse, visitDef: visitDef) {
-              return true
-            }
-          }
-        case let t as TupleInst:
-          if walkDown(t, path: path.push(.tupleField, index: use.index),
-                      followStores: followStores, knownType: knownType,
-                      visitUse: visitUse, visitDef: visitDef) {
-            return true
-          }
-        case let te as TupleExtractInst:
-          if let newPath = pop(.tupleField, index: te.fieldIndex, from: path, yielding: te) {
-            if walkDown(te, path: newPath, followStores: followStores, knownType: knownType,
-                        visitUse: visitUse, visitDef: visitDef) {
-              return true
-            }
-          }
-        case let tea as TupleElementAddrInst:
-          if let newPath = pop(.tupleField, index: tea.fieldIndex, from: path, yielding: tea) {
-            if walkDown(tea, path: newPath, followStores: followStores, knownType: nil,
-                        visitUse: visitUse, visitDef: visitDef) {
-              return true
-            }
-          }
-        case let e as EnumInst:
-          if walkDown(e, path: path.push(.enumCase, index: e.caseIndex),
-                      followStores: followStores, knownType: knownType,
-                      visitUse: visitUse, visitDef: visitDef) {
-            return true
-          }
-        case is UncheckedEnumDataInst, is InitEnumDataAddrInst, is UncheckedTakeEnumDataAddrInst:
-          let svi = user as! SingleValueInstruction
-          let caseIdx = (user as! EnumInstruction).caseIndex
-          if let newPath = pop(.enumCase, index: caseIdx, from: path, yielding: svi) {
-            if walkDown(svi, path: newPath, followStores: followStores, knownType: knownType,
-                        visitUse: visitUse, visitDef: visitDef) {
-              return true
-            }
-          }
-        case let se as SwitchEnumInst:
-          if let (caseIdx, newPath) = path.pop(kind: .enumCase) {
-            if let succBlock = se.getUniqueSuccessor(forCaseIndex: caseIdx) {
-              if let payload = succBlock.arguments.first {
-                if walkDown(payload, path: newPath, followStores: followStores, knownType: knownType,
-                            visitUse: visitUse, visitDef: visitDef) {
-                  return true
-                }
-              }
-            }
-          } else if path.topMatchesAnyValueField {
-            // We don't know the enum case: we have to containue with _all_ cases.
-            for succBlock in se.block.successors {
-              if let payload = succBlock.arguments.first {
-                if walkDown(payload, path: path, followStores: followStores, knownType: knownType,
-                            visitUse: visitUse, visitDef: visitDef) {
-                  return true
-                }
-              }
-            }
-          } else {
-            return isEscaping
-          }
-        case is StoreInst, is StoreWeakInst, is StoreUnownedInst:
-          let store = user as! StoringInstruction
-          if use == store.sourceOperand {
-            if walkUp(store.destination, path: path, followStores: followStores,
-                      visitUse: visitUse, visitDef: visitDef) {
-              return true
-            }
-          } else {
-            assert(use == store.destinationOperand)
-            if let si = store as? StoreInst, si.destinationOwnership == .assign {
-              if handleDestroy(of: value, path: path, followStores: followStores, knownType: nil) {
-                return true
-              }
-            }
-            if followStores {
-              if walkUp(store.source, path: path, followStores: followStores,
-                        visitUse: visitUse, visitDef: visitDef) {
-                return true
-              }
-            }
-          }
-        case let copyAddr as CopyAddrInst:
-          if canIgnoreForLoadOrArgument(path) { continue }
-          if use == copyAddr.sourceOperand {
-            if walkUp(copyAddr.destination, path: path, followStores: followStores,
-                      visitUse: visitUse, visitDef: visitDef) {
-              return true
-            }
-          } else {
-            if !copyAddr.isInitializationOfDest {
-              if handleDestroy(of: value, path: path, followStores: followStores, knownType: nil) {
-                return true
-              }
-            }
-            if followStores {
-              assert(use == copyAddr.destinationOperand)
-              if walkUp(copyAddr.source, path: path, followStores: followStores,
-                        visitUse: visitUse, visitDef: visitDef) {
-                return true
-              }
-            }
-          }
-        case is DestroyValueInst, is ReleaseValueInst, is StrongReleaseInst,
-             is DestroyAddrInst:
-          if handleDestroy(of: value, path: path, followStores: followStores, knownType: knownType) {
-            return true
-          }
-        case let br as BranchInst:
-          // We need to check the cache to avoid cycles and/or exploding complexity in
-          // case of control flow merges.
-          if walkDownAndCache(br.getArgument(for: use), path: path,
-                              followStores: followStores, knownType: knownType,
-                              visitUse: visitUse, visitDef: visitDef) {
-            return true
-          }
-        case let cbr as CondBranchInst:
-          // Same here: we need to check the cache.
-          assert(use.index != 0, "should not visit trivial non-address values")
-          if walkDownAndCache(cbr.getArgument(for: use), path: path,
-                              followStores: followStores, knownType: knownType,
-                              visitUse: visitUse, visitDef: visitDef) {
-            return true
-          }
-        case is ReturnInst:
-          return isEscaping
-        case is ApplyInst, is TryApplyInst, is BeginApplyInst:
-          if walkDownCallee(argOp: use, apply: user as! FullApplySite, path: path,
-                            followStores: followStores, knownType: knownType,
-                            visitUse: visitUse, visitDef: visitDef) {
-            return true
-          }
-        case let pai as PartialApplyInst:
-          if walkDownCallee(argOp: use, apply: pai, path: path,
-                            followStores: followStores, knownType: nil,
-                            visitUse: visitUse, visitDef: visitDef) {
-            return true
-          }
-          // We need to follow the partial_apply value for two reasons:
-          // 1. the closure (with the captured values) itself can escape
-          // 2. something can escape in a destructor when the context is destroyed
-          if walkDown(pai, path: path, followStores: followStores, knownType: nil,
-                      visitUse: visitUse, visitDef: visitDef) {
-            return true
-          }
-
-        case is LoadInst, is LoadWeakInst, is LoadUnownedInst:
-          if canIgnoreForLoadOrArgument(path) { continue }
-          let svi = user as! SingleValueInstruction
-          
-          // Even when analyzing addresses, a loaded trivial value can be ignored.
-          if !svi.type.isNonTrivialOrContainsRawPointer(in: svi.function) { continue }
-
-          if walkDown(svi, path: path,
-                      followStores: followStores, knownType: nil,
-                      visitUse: visitUse, visitDef: visitDef) {
-            return true
-          }
-        case is InitExistentialAddrInst, is OpenExistentialAddrInst, is BeginAccessInst,
-             is PointerToAddressInst, is AddressToPointerInst, is IndexAddrInst:
-          if walkDown(user as! SingleValueInstruction, path: path,
-                      followStores: followStores, knownType: nil,
-                      visitUse: visitUse, visitDef: visitDef) {
-            return true
-          }
-        case is InitExistentialRefInst, is OpenExistentialRefInst,
-             is BeginBorrowInst, is CopyValueInst,
-             is UpcastInst, is UncheckedRefCastInst, is EndCOWMutationInst,
-             is RefToBridgeObjectInst, is BridgeObjectToRefInst:
-          if walkDown(user as! SingleValueInstruction, path: path,
-                      followStores: followStores, knownType: knownType,
-                      visitUse: visitUse, visitDef: visitDef) {
-            return true
-          }
-        case let bcm as BeginCOWMutationInst:
-          if walkDown(bcm.bufferResult, path: path, followStores: followStores, knownType: knownType,
-                          visitUse: visitUse, visitDef: visitDef) {
-            return true
-          }
-        case let mdi as MarkDependenceInst:
-          if use.index == 0 {
-            if walkDown(mdi, path: path, followStores: followStores, knownType: knownType,
-                        visitUse: visitUse, visitDef: visitDef) {
-              return true
-            }
-          }
-        case let bi as BuiltinInst:
-          switch bi.id {
-            case .DestroyArray:
-              if use.index != 1 ||
-                 path.popAllValueFields().popIfMatches(.anyClassField) != nil {
-                return isEscaping
-              }
-            default:
-              return isEscaping
-          }
-        case is DeallocStackInst, is StrongRetainInst, is RetainValueInst,
-             is DebugValueInst, is ValueMetatypeInst, is InjectEnumAddrInst,
-             is InitExistentialMetatypeInst, is OpenExistentialMetatypeInst,
-             is ExistentialMetatypeInst, is DeallocRefInst, is SetDeallocatingInst,
-             is FixLifetimeInst, is ClassifyBridgeObjectInst, is BridgeObjectToWordInst,
-             is EndBorrowInst, is EndAccessInst,
-             is StrongRetainInst, is RetainValueInst,
-             is ClassMethodInst, is SuperMethodInst, is ObjCMethodInst,
-             is ObjCSuperMethodInst, is WitnessMethodInst,is DeallocStackRefInst:
-          break
-        default:
-          return isEscaping
-      }
-    }
-    return false
-  }
-  
-  /// Utility function to continue walking down multi-result instructions, like
-  /// `destructure_struct` and `destructure_tuple`.
-  private mutating
-  func walkDownInstructionResults(results: Instruction.Results,
-                                  fieldKind: Path.FieldKind,
-                                  path: Path, followStores: Bool, knownType: Type?,
-                                  visitUse: UseCallback,
-                                  visitDef: DefCallback) -> Bool {
-    if let (index, newPath) = path.pop(kind: fieldKind) {
-      return walkDown(results[index], path: newPath, followStores: followStores, knownType: knownType,
-                      visitUse: visitUse, visitDef: visitDef)
-    }
-    if path.topMatchesAnyValueField {
-      // We don't know the struct/tuple field: we have to continue with _all_ fields.
-      for result in results where hasRelevantType(result, at: path) {
-        if walkDown(result, path: path, followStores: followStores, knownType: nil,
-                    visitUse: visitUse, visitDef: visitDef) {
-          return true
-        }
-      }
-      return false
-    }
-    return isEscaping
-  }
-
-  /// Handle an apply (full or partial) during the walk-down.
-  private mutating
-  func walkDownCallee(argOp: Operand, apply: ApplySite,
-                      path: Path, followStores: Bool, knownType: Type?,
-                      visitUse: UseCallback, visitDef: DefCallback) -> Bool {
-    guard let argIdx = apply.argumentIndex(of: argOp) else {
-      // The callee or a type dependent operand of the apply does not let escape anything.
-      return false
-    }
-
-    if canIgnoreForLoadOrArgument(path) { return false }
-
-    // Argument effects do not consider any potential stores to the argument (or it's content).
-    // Therefore, if we need to track stores, the argument effects do not correctly describe what we need.
-    // For example, argument 0 in the following function is marked as not-escaping, although there
-    // is a store to the argument:
-    //
-    //   sil [escapes !%0.**] @callee(@inout X, @owned X) -> () {
-    //   bb0(%0 : $*X, %1 : $X):
-    //     store %1 to %0 : $*X
-    //   }
-    if followStores { return isEscaping }
-
-    guard let callees = calleeAnalysis.getCallees(callee: apply.callee) else {
-      // The callees are not know, e.g. if the callee is a closure, class method, etc.
-      return isEscaping
-    }
-
-    let calleeArgIdx = apply.calleeArgIndex(callerArgIndex: argIdx)
-
-    for callee in callees {
-      let effects = callee.effects
-      if !effects.canEscape(argumentIndex: calleeArgIdx, path: path, analyzeAddresses: analyzeAddresses) {
-        continue
-      }
-      if walkDownArgument(calleeArgIdx: calleeArgIdx, argPath: path, knownType: knownType,
-                          apply: apply, effects: effects,
-                          visitUse: visitUse, visitDef: visitDef) {
-        return true
-      }
-    }
-    return false
-  }
-  
-  /// Handle `.escaping` effects for an apply argument during the walk-down.
-  private mutating
-  func walkDownArgument(calleeArgIdx: Int, argPath: Path, knownType: Type?,
-                        apply: ApplySite, effects: FunctionEffects,
-                        visitUse: UseCallback, visitDef: DefCallback) -> Bool {
-    var matched = false
-    for effect in effects.argumentEffects {
-      guard case .escaping(let to, let exclusive) = effect.kind else {
-        continue
-      }
-      if effect.selectedArg.matches(.argument(calleeArgIdx), argPath) {
-        matched = true
-        
-        switch to.value {
-        case .returnValue:
-          guard let fas = apply as? FullApplySite, let result = fas.singleDirectResult else { return isEscaping }
-          
-          if walkDown(result, path: to.pathPattern, followStores: false,
-                      knownType: exclusive ? knownType : nil,
-                      visitUse: visitUse, visitDef: visitDef) {
-            return true
-          }
-        case .argument(let toArgIdx):
-          guard let callerToIdx = apply.callerArgIndex(calleeArgIndex: toArgIdx) else {
-            return isEscaping
-          }
-
-          // Continue at the destination of an arg-to-arg escape.
-          if walkUp(apply.arguments[callerToIdx], path: to.pathPattern, followStores: false,
-                    visitUse: visitUse, visitDef: visitDef) {
-            return true
-          }
-        }
-        continue
-      }
-      // Handle the reverse direction of an arg-to-arg escape.
-      if to.matches(.argument(calleeArgIdx), argPath) {
-        guard let callerArgIdx = apply.callerArgIndex(calleeArgIndex: effect.selectedArg.argumentIndex) else {
-          return isEscaping
-        }
-        if !exclusive { return isEscaping }
-
-        matched = true
-
-        if walkUp(apply.arguments[callerArgIdx], path: effect.selectedArg.pathPattern, followStores: false,
-                  visitUse: visitUse, visitDef: visitDef) {
-          return true
-        }
-        continue
-      }
-    }
-    if !matched { return isEscaping }
-    return false
-  }
-  
-  private func handleDestroy(of value: Value, path: Path, followStores: Bool, knownType: Type?) -> Bool {
-
-    // Even if this is a destroy_value of a struct/tuple/enum, the called destructor(s) only take a
-    // single class reference as parameter.
-    let p = path.popAllValueFields()
-
-    if p.isEmpty {
-      // The object to destroy (= the argument of the destructor) cannot escape itself.
-      return false
-    }
-    if analyzeAddresses && p.matches(pattern: Path(.anyValueFields).push(.anyClassField)) {
-      // Any address of a class property of the object to destroy cannot esacpe the destructor.
-      // (Whereas a value stored in such a property could escape.)
-      return false
-    }
-
-    if followStores {
-      return isEscaping
-    }
-    if let exactTy = knownType {
-      guard let destructor = calleeAnalysis.getDestructor(ofExactType: exactTy) else {
-        return isEscaping
-      }
-      if destructor.effects.canEscape(argumentIndex: 0, path: p, analyzeAddresses: analyzeAddresses) {
-        return isEscaping
-      }
-    } else {
-      // We don't know the exact type, so get all possible called destructure from
-      // the callee analysis.
-      guard let destructors = calleeAnalysis.getDestructors(of: value.type) else {
-        return isEscaping
-      }
-      for destructor in destructors {
-        if destructor.effects.canEscape(argumentIndex: 0, path: p, analyzeAddresses: analyzeAddresses) {
-          return isEscaping
-        }
-      }
-    }
-    return false
-  }
-
-  //===--------------------------------------------------------------------===//
-  //                           walk-up functions
-  //===--------------------------------------------------------------------===//
- 
-  /// The entry point to the up-walk.
-  ///
-  /// It's a no-op if the walkUp is already cached, i.e was already done before with
-  /// the same/matching `path` and `followStores`.
-  ///
-  /// Returns true if the `value` escapes.
-  private mutating
-  func walkUpAndCache(_ value: Value, path: Path, followStores: Bool,
-                      visitUse: UseCallback, visitDef: DefCallback) -> Bool {
-    if let entry = walkedUpCache[value.hashable, default: CacheEntry()].needWalk(path: path, followStores: followStores, knownType: nil) {
-      return walkUp(value, path: entry.path, followStores: entry.followStores,
-                    visitUse: visitUse, visitDef: visitDef)
-    }
-    return false
-  }
-  
-  /// Recursively walks up uses to defs, handling all relevant instructions.
-  ///
-  /// Returns true if the `value` escapes.
-  private mutating
-  func walkUp(_ value: Value, path: Path, followStores: Bool,
-              visitUse: UseCallback, visitDef: DefCallback) -> Bool {
-    var val = value
-    var p = path
-    var fSt = followStores
-    while true {
-      switch visitDef(val, p, fSt) {
-        case .ignore:            return false
-        case .markEscaping:      return isEscaping
-        case .continueWalkingUp: break
-        case .continueWalkingDown:
-          return walkDownAndCache(val, path: p, followStores: fSt, knownType: nil,
-                                  visitUse: visitUse, visitDef: visitDef)
-      }
-      switch val {
-        case is AllocRefInst, is AllocRefDynamicInst:
-          return walkDownAndCache(val, path: p, followStores: fSt, knownType: val.type,
-                                  visitUse: visitUse, visitDef: visitDef)
-        case is AllocRefInst, is AllocRefDynamicInst, is AllocStackInst, is AllocBoxInst:
-          return walkDownAndCache(val, path: p, followStores: fSt, knownType: nil,
-                                  visitUse: visitUse, visitDef: visitDef)
-        case let arg as FunctionArgument:
-          if canIgnoreForLoadOrArgument(path) && arg.isExclusiveIndirectParameter && !fSt {
-            // The address of an indirect argument passed to the current function cannot escape.
-            return walkDownAndCache(val, path: p, followStores: fSt, knownType: nil,
-                                    visitUse: visitUse, visitDef: visitDef)
-          }
-          return isEscaping
-        case let arg as BlockArgument:
-          if arg.isPhiArgument {
-            for incoming in arg.incomingPhiValues {
-              if walkUpAndCache(incoming, path: p, followStores: fSt,
-                                 visitUse: visitUse, visitDef: visitDef) {
-                return true
-              }
-            }
-            return false
-          }
-          let block = arg.block
-          switch block.singlePredecessor!.terminator {
-            case let se as SwitchEnumInst:
-              guard let caseIdx = se.getUniqueCase(forSuccessor: block) else {
-                return isEscaping
-              }
-              val = se.enumOp
-              p = p.push(.enumCase, index: caseIdx)
-            case let ta as TryApplyInst:
-              if block != ta.normalBlock { return isEscaping }
-              return walkUpApplyResult(apply: ta,
-                                       path: p, followStores: fSt,
-                                       visitUse: visitUse, visitDef: visitDef)
-            default:
-              return isEscaping
-          }
-        case let ap as ApplyInst:
-          return walkUpApplyResult(apply: ap,
-                                   path: p, followStores: fSt,
-                                   visitUse: visitUse, visitDef: visitDef)
-        case let str as StructInst:
-          if let (structField, poppedPath) = p.pop(kind: .structField) {
-            val = str.operands[structField].value
-            p = poppedPath
-          } else if p.topMatchesAnyValueField {
-            // We don't know the struct field: we have to continue with _all_ operands.
-            for op in str.operands where hasRelevantType(op.value, at: p) {
-              if walkUpAndCache(op.value, path: p, followStores: fSt, visitUse: visitUse, visitDef: visitDef) {
-                return true
-              }
-            }
-            return false
-          } else {
-            return false
-          }
-        case let se as StructExtractInst:
-          val = se.operand
-          p = p.push(.structField, index: se.fieldIndex)
-        case let t as TupleInst:
-          if let (tupleField, poppedPath) = p.pop(kind: .tupleField) {
-            val = t.operands[tupleField].value
-            p = poppedPath
-          } else if p.topMatchesAnyValueField {
-            // We don't know the tuple element: we have to continue with _all_ operands.
-            for op in t.operands where hasRelevantType(op.value, at: p) {
-              if walkUpAndCache(op.value, path: p, followStores: fSt, visitUse: visitUse, visitDef: visitDef) {
-                return true
-              }
-            }
-            return false
-          } else {
-            return false
-          }
-        case let te as TupleExtractInst:
-          val = te.operand
-          p = p.push(.tupleField, index: te.fieldIndex)
-        case is LoadInst, is LoadWeakInst, is LoadUnownedInst:
-          val = (val as! UnaryInstruction).operand
-          // When the value is loaded from somewhere it also matters what's
-          // stored to that memory location.
-          fSt = true
-        case let rta as RefTailAddrInst:
-          val = rta.operand
-          p = p.push(.tailElements)
-        case let rea as RefElementAddrInst:
-          val = rea.operand
-          p = p.push(.classField, index: rea.fieldIndex)
-        case let pb as ProjectBoxInst:
-          val = pb.operand
-          p = p.push(.classField, index: pb.fieldIndex)
-        case let sea as StructElementAddrInst:
-          p = p.push(.structField, index: sea.fieldIndex)
-          val = sea.operand
-        case let tea as TupleElementAddrInst:
-          p = p.push(.tupleField, index: tea.fieldIndex)
-          val = tea.operand
-        case let e as EnumInst:
-          guard let newPath = p.popIfMatches(.enumCase, index: e.caseIndex) else {
-            return false
-          }
-          guard let op = e.operand else { return false }
-          p = newPath
-          val = op
-        case is UncheckedEnumDataInst, is InitEnumDataAddrInst, is UncheckedTakeEnumDataAddrInst:
-          p = p.push(.enumCase, index: (val as! EnumInstruction).caseIndex)
-          val = (val as! UnaryInstruction).operand
-        case is UpcastInst, is UncheckedRefCastInst,
-             is InitExistentialRefInst, is OpenExistentialRefInst,
-             is InitExistentialAddrInst, is OpenExistentialAddrInst,
-             is BeginAccessInst, is BeginBorrowInst,
-             is EndCOWMutationInst,
-             is RefToBridgeObjectInst, is BridgeObjectToRefInst,
-             is IndexAddrInst, is CopyValueInst, is MarkDependenceInst,
-             is PointerToAddressInst, is AddressToPointerInst:
-          val = (val as! Instruction).operands[0].value
-        case let mvr as MultipleValueInstructionResult:
-          let inst = mvr.instruction
-          switch inst {
-            case let dsi as DestructureStructInst:
-              p = p.push(.structField, index: mvr.index)
-              val = dsi.operand
-            case let dti as DestructureTupleInst:
-              p = p.push(.tupleField, index: mvr.index)
-              val = dti.operand
-            case let bcm as BeginCOWMutationInst:
-              val = bcm.operand
-            default:
-              return isEscaping
-          }
-        default:
-          return isEscaping
-      }
-    }
-  }
- 
-  /// Walks up from the return to the source argument if there is an "exclusive"
-  /// escaping effect on an argument.
-  private mutating
-  func walkUpApplyResult(apply: FullApplySite,
-                         path: Path, followStores: Bool,
-                         visitUse: UseCallback, visitDef: DefCallback) -> Bool {
-    guard let callees = calleeAnalysis.getCallees(callee: apply.callee) else {
-      return isEscaping
-    }
-
-    for callee in callees {
-      var matched = false
-      for effect in callee.effects.argumentEffects {
-        switch effect.kind {
-        case .notEscaping:
-          break
-        case .escaping(let toSelectedArg, let exclusive):
-          if exclusive && toSelectedArg.matches(.returnValue, path) {
-            matched = true
-            if walkUp(apply.arguments[effect.selectedArg.argumentIndex],
-                      path: effect.selectedArg.pathPattern, followStores: followStores,
-                      visitUse: visitUse, visitDef: visitDef) {
-              return true
-            }
-          }
-        }
-      }
-      if !matched {
-        return isEscaping
-      }
-    }
-    return false
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/WalkUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/WalkUtils.swift
@@ -1,0 +1,512 @@
+//===--- WalkUtils.swift - Utilities for use-def def-use walks ------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+
+/// - A `DefUseWalker` finds all uses of a target value.
+///
+/// - A target value is described by a "base" value and a projection path.
+///   1. If the projection path is empty (`""`) then the target value is the base value itself.
+///   2. If the projection path is non-empty (`"s0.1.e3"`), then the target value is the one
+///     reachable from the base through the series of projections described by the path.
+/// - A path can also contain a pattern such as `"v**"` which means any series of "value"
+///   projections (excluding `ref_element_addr` and similar, i.e. `c*`) from any field.
+///   In the `v**` case, the target value*s* are many, i.e. all the ones reachable from
+///   the base through _any of the fields_ through _any number_ of value projections.
+///   `c*` means values reachable through a _single_ projection of _any_ of the fields of the class.
+///
+/// - A walk is started with a call to `walkDownUses(base, path: path, state: state)`.
+/// - This function will call `walkDown(operand, path: path, state: state)`
+///   for every use of `base` as `operand` in an instruction.
+/// - For each use, then the walk can continue with base the result if the result of the using
+///   instruction might still reach the target value with a new projection path.
+///   1. If the use is a construction such as a
+///     `%res = struct $S (%f0)` (or `%res = tuple (%unk, %1)`) instruction and the path is `p`
+///     then the `%res` result value reaches the target value through the new projection`s0.p` (respectively `1.p`).
+///   2.  If the use is a projection such as `%res = struct_extract %s : $S, #S.field0` and the
+///     path is `s0.s1` then the target value is reachable from `%res` with path `s1`.
+///     If the path doesn't match `unmatchedPath` is called.
+///   3. If the use is a "forwarding instruction", such as a cast, the walk continues with the same path.
+///   4. If the use is an unhandled instruction then `leafUse` is called to denote that the client has to
+///     handle this use.
+///
+/// - `State` can be defined by the implementor to track specific state of a "branch"
+///   of the walk, i.e. whether a certain instruction was crossed while walking towards _this use_ of the target.
+///
+/// There are two types of DefUseWalkers, one for values (`ValueDefUseWalker`) and one for
+/// addresses (`AddressDefUseWalker`)
+
+
+/// A `ValueDefUseWalker` can only handle "value" bases, which correspond
+/// to types that are not addresses, i.e. _do not have_ an asterisk (`*`) in the textual
+/// representation of their SIL type (`$T`).
+/// These can be values of reference type, or struct/tuple etc.
+/// A `ValueDefUseWalker.walkDownDefault` called on a use of a "value" base which
+/// yields an "address" value (such as `ref_element_addr %value_base`) will call `leafUse`
+/// since the walk can't proceed.
+/// **All functions return a boolean flag which, if true, can stop the walk of the other uses
+/// and the whole walk.**
+///
+/// Example call `walkDownUses(%str, path: "s0.s1", state: state)`
+/// ```
+/// %fa    = struct_extract %str  : $S1, #S1.fa   // 1. field 0, walkDownUses(%fa, "s1")
+/// %fb    = struct_extract %str  : $S1, #S1.fb   // 5. field 1, unmatchedPath(%str, "s0.s1")
+/// %fa.ga = struct_extract %fa   : $S2, #S2.ga   // 2. field 0, walkDownUses(%fa.ga, "")
+/// ...    = struct_extract %fa.ga: $S3, #S3.ha   // 3. empty path, leafUse(%fa.ga, "")
+/// ...    = <instruction>  %fa.ga:               // 4. unknown instruction, leafUse(%fa.ga, "")
+/// ...    = <instruction>  %str:                 // 6. unknown instruction, leafUse(%str, "s0.s1")
+/// ```
+protocol ValueDefUseWalker {
+  typealias Path = SmallProjectionPath
+  associatedtype State
+  
+  /// Called on each use. The implementor can decide to continue the walk by calling
+  /// `walkDownDefault(value: value, path: path, state: state)` or
+  /// do nothing.
+  mutating func walkDown(value: Operand, path: Path, state: State) -> Bool
+  
+  /// `leafUse` is called from `walkDownDefault` when the walk can't continue for this use since
+  /// either
+  /// * this is an instruction unknown to the default walker which _might_ be a "transitive use"
+  ///   of the target value (such as `destroy_value %base` or a `builtin ... %base` instruction)
+  /// * the `path` is empty (`""`) and therefore this is a "direct use" of the target value.
+  mutating func leafUse(value: Operand, path: Path, state: State) -> Bool
+  
+  /// `unmatchedPath` is called from `walkDownDefault` when this is a use
+  /// of the base value and that the result is unrelated (does not match) with the target
+  /// denoted by `path`.
+  mutating func unmatchedPath(value: Operand, path: Path, state: State) -> Bool
+
+  /// A client must implement this function to cache walking results.
+  /// The function returns nil if the walk doesn't need to continue because
+  /// the `def` was already handled before.
+  /// In case the walk needs to be continued, this function returns the path and state for continuing the walk.
+  ///
+  /// This method is called for two cases:
+  /// 1. To avoid exponential complexity during a walk down with a wildcard path `v**` or `**`
+  ///   ```
+  ///   (%1, %2, %3, %4) = destructure_tuple %t1
+  ///   %t2 = tuple (%1, %2, %3, %4)
+  ///   (%5, %6, %7, %8) = destructure_tuple %t2
+  ///   %t3 = tuple (%5, %6, %7, %8)
+  ///   ```
+  /// 2. To handle "phi webs" of `br` instructions which would lead to an infinite
+  ///   walk down. In this case the implementor must ensure that eventually
+  ///   `shouldRecomputeDown` returns `nil`, i.e. a fixpoint has been reached.
+  ///   - If the implementor doesn't need for the walk to cross phi webs,
+  ///     it can intercept `BranchInst`/`CondBranchInst` in `walkDown` and
+  ///     not call `walkDownDefault` for these cases.
+  ///   - Phi webs arise only for "value" bases.
+  mutating func shouldRecomputeDown(def: Value, path: Path, state: State) -> (Path, State)?
+}
+
+extension ValueDefUseWalker {
+  mutating func walkDown(value operand: Operand, path: Path, state: State) -> Bool {
+    return walkDownDefault(value: operand, path: path, state: state)
+  }
+  
+  mutating func unmatchedPath(value: Operand, path: Path, state: State) -> Bool {
+    return false
+  }
+  
+  /// Given an operand to an instruction, tries to continue the walk with the uses of
+  /// instruction's result if the target value is reachable from it (i.e. matches the `path`) .
+  /// If the walk can't continue, it calls `leafUse` or `unmatchedPath`
+  mutating func walkDownDefault(value operand: Operand, path: Path, state: State) -> Bool {
+    let instruction = operand.instruction
+    switch instruction {
+    case let str as StructInst:
+      return walkDownUses(ofValue: str,
+                      path: path.push(.structField, index: operand.index),
+                      state: state)
+    case let t as TupleInst:
+      return walkDownUses(ofValue: t,
+                      path: path.push(.tupleField, index: operand.index),
+                      state: state)
+    case let e as EnumInst:
+      return walkDownUses(ofValue: e,
+                          path: path.push(.enumCase, index: e.caseIndex),
+                          state: state)
+    case let se as StructExtractInst:
+      if let path = path.popIfMatches(.structField, index: se.fieldIndex) {
+        return walkDownUses(ofValue: se, path: path, state: state)
+      } else {
+        return leafOrUnmatched(value: operand, path: path, state: state)
+      }
+    case let te as TupleExtractInst:
+      if let path = path.popIfMatches(.tupleField, index: te.fieldIndex) {
+        return walkDownUses(ofValue: te, path: path, state: state)
+      } else {
+        return leafOrUnmatched(value: operand, path: path, state: state)
+      }
+    case let ued as UncheckedEnumDataInst:
+      if let path = path.popIfMatches(.enumCase, index: ued.caseIndex) {
+        return walkDownUses(ofValue: ued, path: path, state: state)
+      } else {
+        return leafOrUnmatched(value: operand, path: path, state: state)
+      }
+    case let ds as DestructureStructInst:
+      if let (index, path) = path.pop(kind: .structField) {
+        return walkDownUses(ofValue: ds.results[index], path: path, state: state)
+      } else if path.topMatchesAnyValueField {
+        return walkDownResults(of: ds, path: path, state: state)
+      } else {
+        return leafOrUnmatched(value: operand, path: path, state: state)
+      }
+    case let dt as DestructureTupleInst:
+      if let (index, path) = path.pop(kind: .tupleField) {
+        return walkDownUses(ofValue: dt.results[index], path: path, state: state)
+      } else if path.topMatchesAnyValueField {
+        return walkDownResults(of: dt, path: path, state: state)
+      } else {
+        return leafOrUnmatched(value: operand, path: path, state: state)
+      }
+    case is InitExistentialRefInst, is OpenExistentialRefInst,
+      is BeginBorrowInst, is CopyValueInst,
+      is UpcastInst, is UncheckedRefCastInst, is EndCOWMutationInst,
+      is RefToBridgeObjectInst, is BridgeObjectToRefInst:
+      return walkDownUses(ofValue: (instruction as! SingleValueInstruction), path: path, state: state)
+    case is MarkDependenceInst:
+      assert(operand.index == 1)
+      return unmatchedPath(value: operand, path: path, state: state)
+    case let br as BranchInst:
+      let val = br.getArgument(for: operand)
+      if let (path, state) = shouldRecomputeDown(def: val, path: path, state: state) {
+        return walkDownUses(ofValue: val, path: path, state: state)
+      } else {
+        return false
+      }
+    case let cbr as CondBranchInst:
+      let val = cbr.getArgument(for: operand)
+      if let (path, state) = shouldRecomputeDown(def: val, path: path, state: state) {
+        return walkDownUses(ofValue: val, path: path, state: state)
+      } else {
+        return false
+      }
+    case let bcm as BeginCOWMutationInst:
+      return walkDownUses(ofValue: bcm.bufferResult, path: path, state: state)
+    default:
+      return leafUse(value: operand, path: path, state: state)
+    }
+  }
+  
+  /// Starts the walk
+  mutating func walkDownUses(ofValue: Value, path: Path, state: State) -> Bool {
+    for operand in ofValue.uses where !operand.isTypeDependent {
+      if walkDown(value: operand, path: path, state: state) {
+        return true
+      }
+    }
+    return false
+  }
+  
+  mutating func walkDownResults(of value: MultipleValueInstruction, path: Path, state: State) -> Bool {
+    for result in value.results {
+      if let (path, state) = shouldRecomputeDown(def: result, path: path, state: state) {
+        if walkDownUses(ofValue: result, path: path, state: state) {
+          return true
+        }
+      }
+    }
+    return false
+  }
+  
+  mutating func leafOrUnmatched(value: Operand, path: Path, state: State) -> Bool {
+    if path.isEmpty { return leafUse(value: value, path: path, state: state) }
+    else { return unmatchedPath(value: value, path: path, state: state) }
+  }
+}
+
+/// An `AddressDefUseWalker` can only handle "address" bases, which correspond
+/// to types that are addresses (`$*T`).
+/// An `AddressDefUseWalker.walkDownDefault` called on a use of an "address" base
+/// which results in a "value" (such as `load %addr_base`) will call `leafUse` since the walk
+/// can't proceed.
+/// All functions return a boolean flag which, if true, can stop the walk of the other uses
+/// and the whole walk.
+protocol AddressDefUseWalker {
+  typealias Path = SmallProjectionPath
+  associatedtype State
+  
+  /// Called on each use. The implementor can decide to continue the walk by calling
+  /// `walkDownDefault(address: address, path: path, state: state)` or
+  /// do nothing.
+  mutating func walkDown(address: Operand, path: Path, state: State) -> Bool
+  
+  /// `leafUse` is called from `walkDownDefault` when the walk can't continue for this use since
+  /// either
+  /// * this is an instruction unknown to the default walker which might be a "transitive use"
+  ///   of the target value (such as `destroy_addr %base` or a `builtin ... %base` instruction)
+  /// * the `path` is empty (`""`) and therefore this is a "direct use" of the target value.
+  mutating func leafUse(address: Operand, path: Path, state: State) -> Bool
+  
+  /// `unmatchedPath` is called from `walkDownDefault` when this is a use
+  /// of the base value and that the result is unrelated (does not match) with the target
+  /// denoted by `path`.
+  mutating func unmatchedPath(address: Operand, path: Path, state: State) -> Bool
+}
+
+extension AddressDefUseWalker {
+  mutating func walkDown(address operand: Operand, path: Path, state: State) -> Bool {
+    return walkDownDefault(address: operand, path: path, state: state)
+  }
+  
+  mutating func unmatchedPath(address: Operand, path: Path, state: State) -> Bool {
+    return false
+  }
+  
+  mutating func walkDownDefault(address operand: Operand, path: Path, state: State) -> Bool {
+    let instruction = operand.instruction
+    switch instruction {
+    case let sea as StructElementAddrInst:
+      if let path = path.popIfMatches(.structField, index: sea.fieldIndex) {
+        return walkDownUses(ofAddress: sea, path: path, state: state)
+      } else {
+        return leafOrUnmatched(address: operand, path: path, state: state)
+      }
+    case let tea as TupleElementAddrInst:
+      if let path = path.popIfMatches(.tupleField, index: tea.fieldIndex) {
+        return walkDownUses(ofAddress: tea, path: path, state: state)
+      } else {
+        return leafOrUnmatched(address: operand, path: path, state: state)
+      }
+    case is InitEnumDataAddrInst, is UncheckedTakeEnumDataAddrInst:
+      let ei = instruction as! SingleValueInstruction
+      if let path = path.popIfMatches(.enumCase, index: (instruction as! EnumInstruction).caseIndex) {
+        return walkDownUses(ofAddress: ei, path: path, state: state)
+      } else {
+        return leafOrUnmatched(address: operand, path: path, state: state)
+      }
+    case is InitExistentialAddrInst, is OpenExistentialAddrInst, is BeginAccessInst,
+      is IndexAddrInst:
+      return walkDownUses(ofAddress: instruction as! SingleValueInstruction, path: path, state: state)
+    case let mdi as MarkDependenceInst:
+      assert(operand.index == 0)
+      return walkDownUses(ofAddress: mdi, path: path, state: state)
+    default:
+      return leafUse(address: operand, path: path, state: state)
+    }
+  }
+  
+  mutating func walkDownUses(ofAddress: Value, path: Path, state: State) -> Bool {
+    for operand in ofAddress.uses where !operand.isTypeDependent {
+      if walkDown(address: operand, path: path, state: state) {
+        return true
+      }
+    }
+    return false
+  }
+  
+  mutating func leafOrUnmatched(address: Operand, path: Path, state: State) -> Bool {
+    if path.isEmpty { return leafUse(address: address, path: path, state: state) }
+    else { return unmatchedPath(address: address, path: path, state: state) }
+  }
+}
+
+/// - A `UseDefWalker` can be used to find all "generating" definitions of
+///   a target value.
+/// - A target value is described by a "base" value and a projection path as in a `DefUseWalker.`
+///   1. If the projection path is empty (`""`) then the target value is the base value itself.
+///   2. If the projection path is non-empty (`"s0.1.e3"`), then the target value is the one
+///     reachable through the series of projections described by the path, applied to the base.
+/// - The same notes about wildcard paths in `DefUseWalker` apply here.
+///
+/// - A walk is started with a call to `walkUp(base, path: path, state: state)`.
+///
+/// - The implementor of `walkUp` can then track the definition if needed and
+///   continue the walk by calling `walkUpDefault`.
+///   `walkUpDefault` will do the following:
+///   1. If the instruction of the definition is a projection, then it will continue
+///     the walk by calling `walkUp` on the operand definition and an adjusted (pushed) path
+///     to reflect that a further projection is needed to reach the value of interest from the new initial value.
+///   2. If the instruction of the definition is a value construction such as `struct` and
+///     the head of the path matches the instruction type then the walk continues
+///     with a call to `walkUp` with initial value the operand defintion denoted by the path
+///     and the suffix path as path since the target value can now be reached with fewer projections.
+///     If the defining instruction of the value does not match the head of the path as in
+///     `%t = tuple ...` and `"s0.t1"` then `unmatchedPath(%t, ...)` is called.
+///   3. If the instruction is a forwarding instruction, such as a cast, the walk continues with `walkUp`
+///     with the operand definition as initial value and same path.
+///   4. If the instruction is not handled by this walker or the path is empty, then `rootDef` is called to
+///     denote that the walk can't continue and that the definition of the target has been reached.
+protocol ValueUseDefWalker {
+  typealias Path = SmallProjectionPath
+  associatedtype State
+  
+  /// Starting point of the walk. The implementor can decide to continue the walk by calling
+  /// `walkUpDefault(value: value, path: path, state: state)` or
+  /// do nothing.
+  mutating func walkUp(value: Value, path: Path, state: State) -> Bool
+  
+  /// `rootDef` is called from `walkUpDefault` when the walk can't continue for this use since
+  /// either
+  /// * the defining instruction is unknown to the default walker
+  /// * the `path` is empty (`""`) and therefore this is the definition of the target value.
+  mutating func rootDef(value: Value, path: Path, state: State) -> Bool
+  
+  /// `unmatchedPath` is called from `walkUpDefault` when the defining instruction
+  /// is unrelated to the `path` the walk should follow.
+  mutating func unmatchedPath(value: Value, path: Path, state: State) -> Bool
+  
+  /// A client must implement this function to cache walking results.
+  /// The function returns nil if the walk doesn't need to continue because
+  /// the `def` was already handled before.
+  /// In case the walk needs to be continued, this function returns the path
+  /// and state for continuing the walk.
+  mutating func shouldRecomputeUp(def: Value, path: Path, state: State) -> (Path, State)?
+}
+
+extension ValueUseDefWalker {
+  mutating func walkUp(value: Value, path: Path, state: State) -> Bool {
+    return walkUpDefault(value: value, path: path, state: state)
+  }
+  
+  mutating func unmatchedPath(value: Value, path: Path, state: State) -> Bool {
+    return false
+  }
+  
+  mutating func walkUpDefault(value def: Value, path: Path, state: State) -> Bool {
+    switch def {
+    case let str as StructInst:
+      if let (index, path) = path.pop(kind: .structField) {
+        return walkUp(value: str.operands[index].value, path: path, state: state)
+      } else if path.topMatchesAnyValueField {
+        return walkUpOperands(of: str, path: path, state: state)
+      } else {
+        return rootOrUnmatched(value: str, path: path, state: state)
+      }
+    case let t as TupleInst:
+      if let (index, path) = path.pop(kind: .tupleField) {
+        return walkUp(value: t.operands[index].value, path: path, state: state)
+      } else if path.topMatchesAnyValueField {
+        return walkUpOperands(of: t, path: path, state: state)
+      } else {
+        return rootOrUnmatched(value: t, path: path, state: state)
+      }
+    case let e as EnumInst:
+      if let path = path.popIfMatches(.enumCase, index: e.caseIndex),
+         let operand = e.operand {
+        return walkUp(value: operand, path: path, state: state)
+      } else {
+        return rootOrUnmatched(value: e, path: path, state: state)
+      }
+    case let se as StructExtractInst:
+      return walkUp(value: se.operand, path: path.push(.structField, index: se.fieldIndex), state: state)
+    case let te as TupleExtractInst:
+      return walkUp(value: te.operand, path: path.push(.tupleField, index: te.fieldIndex), state: state)
+    case let ued as UncheckedEnumDataInst:
+      return walkUp(value: ued.operand, path: path.push(.enumCase, index: ued.caseIndex), state: state)
+    case let mvr as MultipleValueInstructionResult:
+      let instruction = mvr.instruction
+      if let ds = instruction as? DestructureStructInst {
+        return walkUp(value: ds.operand, path: path.push(.structField, index: mvr.index), state: state)
+      } else if let dt = instruction as? DestructureTupleInst {
+        return walkUp(value: dt.operand, path: path.push(.tupleField, index: mvr.index), state: state)
+      } else if let bcm = instruction as? BeginCOWMutationInst {
+        return walkUp(value: bcm.operand, path: path, state: state)
+      } else {
+        return rootDef(value: mvr, path: path, state: state)
+      }
+    case is InitExistentialRefInst, is OpenExistentialRefInst,
+      is BeginBorrowInst, is CopyValueInst,
+      is UpcastInst, is UncheckedRefCastInst, is EndCOWMutationInst,
+      is RefToBridgeObjectInst, is BridgeObjectToRefInst:
+      return walkUp(value: (def as! Instruction).operands[0].value, path: path, state: state)
+    case let arg as BlockArgument where arg.isPhiArgument:
+      for incoming in arg.incomingPhiValues {
+        // `shouldRecomputeUp` is called to avoid cycles in the walk
+        if let (path, state) = shouldRecomputeUp(def: incoming, path: path, state: state) {
+          if walkUp(value: incoming, path: path, state: state) {
+            return true
+          }
+        }
+      }
+      return false
+    default:
+      return rootDef(value: def, path: path, state: state)
+    }
+  }
+  
+  mutating func walkUpOperands(of def: SingleValueInstruction, path: Path, state: State) -> Bool {
+    for operand in def.operands {
+      // `shouldRecompute` is called to avoid exponential complexity in
+      // programs like
+      //
+      // (%1, %2) = destructure_struct %0
+      // %3 = struct $Struct %1 %2
+      // (%4, %5) = destructure_struct %3
+      // %6 = struct $Struct %4 %5
+      if let (path, state) = shouldRecomputeUp(def: operand.value, path: path, state: state) {
+        if walkUp(value: operand.value, path: path, state: state) {
+          return true
+        }
+      }
+    }
+    return false
+  }
+  
+  mutating func rootOrUnmatched(value: Value, path: Path, state: State) -> Bool {
+    if path.isEmpty { return rootDef(value: value, path: path, state: state) }
+    else { return unmatchedPath(value: value, path: path, state: state) }
+  }
+  
+}
+
+protocol AddressUseDefWalker {
+  typealias Path = SmallProjectionPath
+  associatedtype State
+  
+  /// Starting point of the walk. The implementor can decide to continue the walk by calling
+  /// `walkUpDefault(address: address, path: path, state: state)` or
+  /// do nothing.
+  mutating func walkUp(address: Value, path: Path, state: State) -> Bool
+  
+  /// `rootDef` is called from `walkUpDefault` when the walk can't continue for this use since
+  /// either
+  /// * the defining instruction is unknown to the default walker
+  /// * the `path` is empty (`""`) and therefore this is the definition of the target value.
+  mutating func rootDef(address: Value, path: Path, state: State) -> Bool
+  
+  /// `unmatchedPath` is called from `walkUpDefault` when the defining instruction
+  /// is unrelated to the `path` the walk should follow.
+  mutating func unmatchedPath(address: Value, path: Path, state: State) -> Bool
+}
+
+extension AddressUseDefWalker {
+  
+  mutating func walkUp(address: Value, path: Path, state: State) -> Bool {
+    return walkUpDefault(address: address, path: path, state: state)
+  }
+  
+  mutating func unmatchedPath(address: Value, path: Path, state: State) -> Bool {
+    return false
+  }
+  
+  mutating func walkUpDefault(address def: Value, path: Path, state: State) -> Bool {
+    switch def {
+    case let sea as StructElementAddrInst:
+      return walkUp(address: sea.operand, path: path.push(.structField, index: sea.fieldIndex), state: state)
+    case let tea as TupleElementAddrInst:
+      return walkUp(address: tea.operand, path: path.push(.tupleField, index: tea.fieldIndex), state: state)
+    case is InitEnumDataAddrInst, is UncheckedTakeEnumDataAddrInst:
+      return walkUp(address: (def as! UnaryInstruction).operand,
+                    path: path.push(.enumCase, index: (def as! EnumInstruction).caseIndex), state: state)
+    case is InitExistentialAddrInst, is OpenExistentialAddrInst, is BeginAccessInst, is IndexAddrInst:
+      return walkUp(address: (def as! Instruction).operands[0].value, path: path, state: state)
+    case let mdi as MarkDependenceInst:
+      return walkUp(address: mdi.operands[0].value, path: path, state: state)
+    default:
+      return rootDef(address: def, path: path, state: state)
+    }
+  }
+}


### PR DESCRIPTION
This PR adds  def-use/use-def traversals in `WalkUtils.swift` and updates `EscapeInfo` and related passes to use those.

`WalkUtils` adds a set of protocols (`ValueDefUseWalker`, `AddressDefUseWalker`, `ValueUseDefWalker`, `AddressUseDefWalker`) that perform def-use and use-def traversals guided by a projection path.
An implementor of these protocols can collect uses/definitions and track whether
certain instructions have been crossed during the traversal.

Additionally `EscapeInfo` and related passes are updated to use the traversal utilities.